### PR TITLE
Permissions middleware fix

### DIFF
--- a/src/Middleware/PermissionMiddleware.php
+++ b/src/Middleware/PermissionMiddleware.php
@@ -45,11 +45,8 @@ class PermissionMiddleware
      */
     public function handle(Request $request, Closure $next, ...$permissions)
     {
-        $accessDenied = true;
-
         if (!$user = $this->auth->getActiveUser()) {
             Flash::error(trans('dashboard::dashboard.flash.access_denied'));
-
             return redirect()->back();
         }
 
@@ -57,19 +54,11 @@ class PermissionMiddleware
             $permissions = [$permissions];
         }
 
-        foreach ($permissions as $permission) {
-
-            if ($user->hasAccess($permission)) {
-                $accessDenied = false;
-            }
+        if ($user->hasAnyAccess($permissions)) {
+            return $next($request);
         }
 
-        if ($accessDenied) {
-            Flash::error(trans('dashboard::dashboard.flash.access_denied'));
-
-            return redirect()->back();
-        }
-
-        return $next($request);
+        Flash::error(trans('dashboard::dashboard.flash.access_denied'));
+        return redirect()->back();
     }
 }

--- a/src/Middleware/PermissionMiddleware.php
+++ b/src/Middleware/PermissionMiddleware.php
@@ -43,7 +43,7 @@ class PermissionMiddleware
      *
      * @return \Illuminate\Http\RedirectResponse
      */
-    public function handle(Request $request, Closure $next, $permissions)
+    public function handle(Request $request, Closure $next, ...$permissions)
     {
         $accessDenied = true;
 


### PR DESCRIPTION
In doesn't work this way, all values returns as separate arguments like:
`public function handle(Request $request, Closure $next, $first, $second, ...)`
So with this code always checking only first permission
